### PR TITLE
Fixed filtering and removed wireguard interfaces from check_wireguard

### DIFF
--- a/check_opnsense.py
+++ b/check_opnsense.py
@@ -405,6 +405,10 @@ class CheckOPNsense:
             peer_status = wgs.get("peer-status", "offline")
             name = wgs.get("name", "unknown")
             endpoint = wgs.get("endpoint", "unknown")
+            wg_type = wgs.get("type", "peer")
+
+            if wg_type != "peer":
+                continue
 
             if name not in self.options.filter:
                 if peer_status == "online":

--- a/check_opnsense.py
+++ b/check_opnsense.py
@@ -139,6 +139,11 @@ class CheckOPNsense:
         """Execute the real check command."""
         self.check_result = CheckState.OK
 
+        if self.options.filter:
+            self.options.filter = self.options.filter.split(",")
+        else:
+            self.options.filter = []
+
         if self.options.mode == "updates":
             self.check_updates()
         elif self.options.mode == "ipsec":
@@ -152,11 +157,6 @@ class CheckOPNsense:
         else:
             message = f"Check mode '{self.options.mode}' not known"
             self.output(CheckState.UNKNOWN, message)
-
-        if self.options.filter:
-            self.options.filter = self.options.filter.split(",")
-        else:
-            self.options.filter = []
 
         self.check_output()
 


### PR DESCRIPTION
This fixes two small things:

1. Filtering for a string with a dash in it would also result in filtering for the part of the string after the dash.
For example: Have two wireguard peers, one called "foo-bar" and the other called "bar". Hiding the "foo-bar" peer by filtering for it (-f "foo-bar") would also hide the peer called "bar". Moving the code block where options.filter gets split before check execution fixes this. Don't ask me why.

2. check_wireguard returned results for wireguard peers and wireguard interfaces. The wireguard interfaces are already monitored by check_interfaces. Additionally check_wireguard always considered interfaces as offline. Simply checking the type of a row and skipping ahead if it is not a "peer" fixes this. 